### PR TITLE
Implementation of config replacement method

### DIFF
--- a/napalm_aruba505/__init__.py
+++ b/napalm_aruba505/__init__.py
@@ -4,4 +4,4 @@
 from napalm_aruba505.aruba505 import Aruba505Driver
 __all__ = ('Aruba505Driver',)
 
-__version__ = "0.0.170"
+__version__ = "0.0.171"

--- a/napalm_aruba505/aruba505.py
+++ b/napalm_aruba505/aruba505.py
@@ -524,8 +524,9 @@ class Aruba505Driver(NetworkDriver):
                 # only replace config part, when diff has been found
                 if self.has_diff.get(config_part):
                     self._wrapper_replace_config_part(config_part=config_part, commands=config_part_cmds)
-        # permanently save configuration
-        self.device.send_command("commit apply")
+        # permanently save configuration #
+        # 'commit apply' does not work even though it should according to documentation
+        self.device.send_command("write memory")
 
     def discard_config(self) -> None:
         """

--- a/napalm_aruba505/aruba505.py
+++ b/napalm_aruba505/aruba505.py
@@ -1,16 +1,9 @@
 # -*- coding: utf-8 -*-
 """NAPALM ArubaOS Five zero five Handler."""
 
-import copy
-import functools
-import os
 import re
 import socket
-import telnetlib
-import tempfile
 import time
-import uuid
-from collections import defaultdict
 import difflib
 from netaddr import IPNetwork
 from netaddr.core import AddrFormatError

--- a/napalm_aruba505/aruba505.py
+++ b/napalm_aruba505/aruba505.py
@@ -68,7 +68,7 @@ class Aruba505Driver(NetworkDriver):
             "general": False,
             "snmp": False,
             "radio": False,
-            "syslog": False,
+            "services": False,
             "manager": False,
             "access_rules": False,
             "ssid_profile": False,
@@ -227,7 +227,7 @@ class Aruba505Driver(NetworkDriver):
             "general": [],
             "snmp": [],
             "radio": [],
-            "syslog": [],
+            "services": [],
             "manager": [],
             "access_rules": [],
             "ssid_profile": [],
@@ -241,7 +241,7 @@ class Aruba505Driver(NetworkDriver):
             "general": {"start": ":", "end": "", "end_before": ""},
             "snmp": {"start": "snmp-server", "end": "snmp-server", "end_before": ""},
             "radio": {"start": "arm", "end": "", "end_before": "syslog-level"},
-            "syslog": {"start": "syslog-level", "end": "", "end_before": ""},
+            "services": {"start": "syslog-level", "end": "", "end_before": "hash-mgmt-"},
             "manager": {"start": "hash-mgmt-", "end": "hash-mgmt-", "end_before": ""},
             "access_rules": {"start": "wlan access-rule", "end": "", "end_before": ""},
             "ssid_profile": {"start": "wlan ssid-profile", "end": "", "end_before": ""},
@@ -384,9 +384,9 @@ class Aruba505Driver(NetworkDriver):
             if any(line == "arm" for line in commands) and not any(line == "80mhz-support" for line in commands):
                 commands_at_end.append("arm")
                 commands_at_end.append(" no 80mhz-support")
-        elif config_part == "syslog":
-            # simply overwrite existing config
-            pass
+        elif config_part == "services":
+            commands_at_start.append("no web-server")
+            commands_at_start.append("no allow-rest-api")
         elif config_part == "manager":
             remove_string = "hash-mgmt-user"
             for line in self.pre_change_dict.get("manager"):
@@ -524,6 +524,7 @@ class Aruba505Driver(NetworkDriver):
             commands = clean_commands
         elif config_part == "trailer":
             commands_at_start.append("no uplink")
+            commands_at_start.append("no cluster-security")
         # insert commands to remove features before all other commands
         if commands_at_start:
             commands_at_start += commands
@@ -581,7 +582,7 @@ class Aruba505Driver(NetworkDriver):
             "general": False,
             "snmp": False,
             "radio": False,
-            "syslog": False,
+            "services": False,
             "manager": False,
             "access_rules": False,
             "ssid_profile": False,

--- a/napalm_aruba505/aruba505.py
+++ b/napalm_aruba505/aruba505.py
@@ -346,7 +346,7 @@ class Aruba505Driver(NetworkDriver):
             config1 = []
         if config2 == None:
             config2 = []
-        diff = difflib.context_diff(config1, config2)
+        diff = difflib.context_diff(config1, config2, n=8)
         try:
             _ = next(diff)
         except StopIteration:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
-import setuptools
 """setup.py file."""
+import setuptools
 
 # read the contents of your README file
 with open("README.md", "r") as fh:
@@ -7,8 +7,8 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name = "napalm_aruba505",
-    version = "0.0.170",
-    author = "David Johnnes",
+    version = "0.0.171",
+    author = "David Johnnes, Sonja Karpe",
     author_email = "david.johnnes@gmail.com",
     description = ("Napalm Aruba driver for ArubaOS Wi-Fi devices '505' "),
     license = "Apache 2",


### PR DESCRIPTION
Since Aruba Access Points do not have a candidate data store, this driver tries to imitate the behavior.

- load_replace_candidate -> Loads new config into a class attribute instead.
- compare_config -> Produces diff and also a sequence of commands that would be executed to achieve the new target config. Config references will be removed and re-added automatically, if needed.
- commit_config -> Send commands only for the config parts, that deviate from the new target config.

This implementation allows the driver to be used with the [napalm-ansible](https://github.com/napalm-automation/napalm-ansible/tree/develop) module.
